### PR TITLE
remove the redundant import which causes issue on OSD

### DIFF
--- a/src/robot/libraries/BuiltIn.py
+++ b/src/robot/libraries/BuiltIn.py
@@ -21,7 +21,6 @@ import re
 import time
 # cuongnht add thread
 import threading, queue
-from pywin.mfc import thread
 
 from robot.api import logger, SkipExecution
 from robot.api.deco import keyword


### PR DESCRIPTION
Hi Thomas,

This change removes the redundant import in Cuong's implementation which causes the issue on OSD.
That import is by chance added by the IDE.

Thank you,
Ngoan