### PR TITLE
*Fixed to raise unknown state when AttributeError occurs

### DIFF
--- a/src/robot/errors.py
+++ b/src/robot/errors.py
@@ -191,7 +191,8 @@ class HandlerExecutionFailed(ExecutionFailed):
     def __init__(self, details):
         error = details.error
         timeout = isinstance(error, TimeoutError)
-        unknown = isinstance(error, UnknownAssertionError) or type(error) == Exception
+        unknown = isinstance(error, UnknownAssertionError) or type(error) == Exception \
+                                                           or isinstance(error, AttributeError)
         test_timeout = timeout and error.test_timeout
         keyword_timeout = timeout and error.keyword_timeout
         syntax = isinstance(error, DataError) and error.syntax


### PR DESCRIPTION
*Fixed for https://github.com/test-fullautomation/robotframework/issues/113: Missing keyword caused "FAIL"